### PR TITLE
New release 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,11 @@
+# Changelog
+## [0.2.0] - 2023-07-10
+### Breaking changes
+ - Removed reexport on `nl`, please use `netlink_packet_core`. (a7bfcfd)
+ - Removed reexport on `utils`, please use `netlink_packet_utils`. (a7bfcfd)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Loïc Damien <loic.damien@dzamlo.ch>"]
 name = "netlink-packet-netfilter"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-netfilter"


### PR DESCRIPTION
=== Breaking changes
 - Removed reexport on `nl`, please use `netlink_packet_core`. (a7bfcfd)
 - Removed reexport on `utils`, please use `netlink_packet_utils`. (a7bfcfd)

=== New features
 - N/A

=== Bug fixes
 - N/A