### PR TITLE
Implement the parsing of conntrack messages over the netfilter protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 authors = ["Loïc Damien <loic.damien@dzamlo.ch>"]
-name = "netlink-packet-netfilter"
+name = "reyzell-netlink-packet-netfilter"
 version = "0.2.0"
 edition = "2018"
 
-homepage = "https://github.com/rust-netlink/netlink-packet-netfilter"
+homepage = "https://github.com/reyzell/netlink-packet-netfilter"
 keywords = ["netlink", "linux", "netfilter"]
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/rust-netlink/netlink-packet-netfilter"
+repository = "https://github.com/reyzell/netlink-packet-netfilter"
 description = "netlink packet types for the netfilter subprotocol"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Rust netlink packet types for the netfilter subprotocol
+
+This is a temporary fork of `netlink-packet-netfilter` [a] until conntrack
+support is merged in.
+
+[a] https://github.com/rust-netlink/netlink-packet-netfilter

--- a/examples/nfconntrack.rs
+++ b/examples/nfconntrack.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+
+// To run this example:
+//   1) build the example: cargo build --example nfconntrack
+//   2) run it as root: sudo ../target/debug/examples/nfconntrack
+//   3) Perform network activity from your host, which would result in conntrack updates:
+//      curl http://example.com
+
+use netlink_packet_netfilter::{
+    constants::{NFNLGRP_CONNTRACK_NEW, NFNLGRP_CONNTRACK_DESTROY},
+    nfconntrack::{
+        nlas::{ConnectionProperties, ConnectionTuple},
+        ConnectionNla, NfConntrackMessage,
+    },
+    NetfilterMessage, NetfilterMessageInner,
+};
+use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
+use netlink_sys::{constants::NETLINK_NETFILTER, Socket};
+
+use std::convert::TryFrom;
+
+fn print_connection_tuple(tuple: ConnectionTuple) {
+    match ConnectionProperties::try_from(tuple) {
+        Ok(cxn) => {
+            print!("{:?} ", cxn)
+        }
+        Err(e) => {
+            print!("[error] {:?} ", e)
+        }
+    }
+}
+
+fn print_connection_nla(nlas: Vec<ConnectionNla>) {
+    for nla in nlas {
+        match nla {
+            ConnectionNla::TupleOrig(tuple) => {
+                print!("[orig] ");
+                print_connection_tuple(tuple);
+            }
+            ConnectionNla::TupleReply(tuple) => {
+                print!("[reply] ");
+                print_connection_tuple(tuple);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn main() {
+    let mut receive_buffer = vec![0; 4096];
+
+    let mut socket = Socket::new(NETLINK_NETFILTER).unwrap();
+    socket.bind_auto().unwrap();
+    socket.add_membership(NFNLGRP_CONNTRACK_NEW as u32).unwrap();
+    socket.add_membership(NFNLGRP_CONNTRACK_DESTROY as u32).unwrap();
+
+    loop {
+        match socket.recv(&mut &mut receive_buffer[..], 0) {
+            Ok(_size) => {
+                let bytes = &receive_buffer[..];
+                let msg =
+                    <NetlinkMessage<NetfilterMessage>>::deserialize(bytes)
+                        .unwrap();
+                if let NetlinkPayload::<NetfilterMessage>::InnerMessage(imsg) =
+                    msg.payload
+                {
+                    if let NetfilterMessageInner::NfConntrack(ct) = imsg.inner {
+                        match ct {
+                            NfConntrackMessage::ConnectionNew(nlas) => {
+                                print!("[new] ");
+                                print_connection_nla(nlas);
+                                println!();
+                            }
+                            NfConntrackMessage::ConnectionDelete(nlas) => {
+                                print!("[delete] ");
+                                print_connection_nla(nlas);
+                                println!();
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                println!("error while receiving packets: {:?}", e);
+                break;
+            }
+        }
+    }
+}

--- a/examples/nfconntrack.rs
+++ b/examples/nfconntrack.rs
@@ -6,7 +6,7 @@
 //   3) Perform network activity from your host, which would result in conntrack updates:
 //      curl http://example.com
 
-use netlink_packet_netfilter::{
+use reyzell_netlink_packet_netfilter::{
     constants::{NFNLGRP_CONNTRACK_NEW, NFNLGRP_CONNTRACK_DESTROY},
     nfconntrack::{
         nlas::{ConnectionProperties, ConnectionTuple},

--- a/examples/nflog.rs
+++ b/examples/nflog.rs
@@ -10,7 +10,7 @@ use std::{net::Ipv4Addr, time::Duration};
 
 use byteorder::{ByteOrder, NetworkEndian};
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
-use netlink_packet_netfilter::{
+use reyzell_netlink_packet_netfilter::{
     constants::*,
     nflog::{
         config_request,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,6 +5,7 @@ use crate::{
         NetfilterHeader, NetfilterMessage, NetfilterMessageInner,
         NETFILTER_HEADER_LEN,
     },
+    nfconntrack::NfConntrackMessage,
     nflog::NfLogMessage,
 };
 use anyhow::Context;
@@ -56,6 +57,10 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         let subsys = (message_type >> 8) as u8;
         let message_type = message_type as u8;
         let inner = match subsys {
+            NfConntrackMessage::SUBSYS => NetfilterMessageInner::NfConntrack(
+                NfConntrackMessage::parse_with_param(buf, message_type)
+                    .context("failed to parse nfconntrack payload")?,
+            ),
             NfLogMessage::SUBSYS => NetfilterMessageInner::NfLog(
                 NfLogMessage::parse_with_param(buf, message_type)
                     .context("failed to parse nflog payload")?,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -88,3 +88,32 @@ pub const NFULA_CT_INFO: u16 = libc::NFULA_CT_INFO as u16;
 
 pub const NFULNL_MSG_CONFIG: u8 = libc::NFULNL_MSG_CONFIG as u8;
 pub const NFULNL_MSG_PACKET: u8 = libc::NFULNL_MSG_PACKET as u8;
+
+pub const NFNLGRP_CONNTRACK_NEW: u32 = 1;
+pub const NFNLGRP_CONNTRACK_UPDATE: u32 = 2;
+pub const NFNLGRP_CONNTRACK_DESTROY: u32 = 3;
+
+pub const IPCTNL_MSG_CT_NEW: u8 = 0;
+pub const IPCTNL_MSG_CT_GET: u8 = 1;
+pub const IPCTNL_MSG_CT_DELETE: u8 = 2;
+pub const IPCTNL_MSG_CT_GET_CTRZERO: u8 = 3;
+pub const IPCTNL_MSG_CT_GET_STATS_CPU: u8 = 4;
+pub const IPCTNL_MSG_CT_GET_STATS: u8 = 5;
+pub const IPCTNL_MSG_CT_GET_DYING: u8 = 6;
+pub const IPCTNL_MSG_CT_GET_UNCONFIRMED: u8 = 7;
+
+pub const CTA_TUPLE_ORIG: u16 = 1;
+pub const CTA_TUPLE_REPLY: u16 = 2;
+
+pub const CTA_TUPLE_IP: u16 = 1;
+pub const CTA_TUPLE_PROTO: u16 = 2;
+pub const CTA_TUPLE_ZONE: u16 = 3;
+
+pub const CTA_IP_V4_SRC: u16 = 1;
+pub const CTA_IP_V4_DST: u16 = 2;
+pub const CTA_IP_V6_SRC: u16 = 3;
+pub const CTA_IP_V6_DST: u16 = 4;
+
+pub const CTA_PROTO_NUM: u16 = 1;
+pub const CTA_PROTO_SRC_PORT: u16 = 2;
+pub const CTA_PROTO_DST_PORT: u16 = 3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub(crate) mod buffer;
 pub mod constants;
 mod message;
 pub use message::{NetfilterHeader, NetfilterMessage, NetfilterMessageInner};
+pub mod nfconntrack;
 pub mod nflog;

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,7 +8,10 @@ use netlink_packet_utils::{
     ParseableParametrized,
 };
 
-use crate::{buffer::NetfilterBuffer, nflog::NfLogMessage};
+use crate::{
+    buffer::NetfilterBuffer, nfconntrack::NfConntrackMessage,
+    nflog::NfLogMessage,
+};
 
 pub const NETFILTER_HEADER_LEN: usize = 4;
 
@@ -61,12 +64,19 @@ impl<T: AsRef<[u8]>> Parseable<NetfilterHeaderBuffer<T>> for NetfilterHeader {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum NetfilterMessageInner {
+    NfConntrack(NfConntrackMessage),
     NfLog(NfLogMessage),
     Other {
         subsys: u8,
         message_type: u8,
         nlas: Vec<DefaultNla>,
     },
+}
+
+impl From<NfConntrackMessage> for NetfilterMessageInner {
+    fn from(message: NfConntrackMessage) -> Self {
+        Self::NfConntrack(message)
+    }
 }
 
 impl From<NfLogMessage> for NetfilterMessageInner {
@@ -78,7 +88,8 @@ impl From<NfLogMessage> for NetfilterMessageInner {
 impl Emitable for NetfilterMessageInner {
     fn buffer_len(&self) -> usize {
         match self {
-            NetfilterMessageInner::NfLog(message) => message.buffer_len(),
+            NetfilterMessageInner::NfConntrack(msg) => msg.buffer_len(),
+            NetfilterMessageInner::NfLog(msg) => msg.buffer_len(),
             NetfilterMessageInner::Other { nlas, .. } => {
                 nlas.as_slice().buffer_len()
             }
@@ -87,7 +98,8 @@ impl Emitable for NetfilterMessageInner {
 
     fn emit(&self, buffer: &mut [u8]) {
         match self {
-            NetfilterMessageInner::NfLog(message) => message.emit(buffer),
+            NetfilterMessageInner::NfConntrack(msg) => msg.emit(buffer),
+            NetfilterMessageInner::NfLog(msg) => msg.emit(buffer),
             NetfilterMessageInner::Other { nlas, .. } => {
                 nlas.as_slice().emit(buffer)
             }
@@ -114,6 +126,7 @@ impl NetfilterMessage {
 
     pub fn subsys(&self) -> u8 {
         match self.inner {
+            NetfilterMessageInner::NfConntrack(_) => NfConntrackMessage::SUBSYS,
             NetfilterMessageInner::NfLog(_) => NfLogMessage::SUBSYS,
             NetfilterMessageInner::Other { subsys, .. } => subsys,
         }
@@ -121,7 +134,8 @@ impl NetfilterMessage {
 
     pub fn message_type(&self) -> u8 {
         match self.inner {
-            NetfilterMessageInner::NfLog(ref message) => message.message_type(),
+            NetfilterMessageInner::NfConntrack(ref msg) => msg.message_type(),
+            NetfilterMessageInner::NfLog(ref msg) => msg.message_type(),
             NetfilterMessageInner::Other { message_type, .. } => message_type,
         }
     }

--- a/src/nfconntrack/message.rs
+++ b/src/nfconntrack/message.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{
+    nla::DefaultNla, DecodeError, Emitable, Parseable, ParseableParametrized,
+};
+
+use crate::{
+    buffer::NetfilterBuffer,
+    constants::{
+        IPCTNL_MSG_CT_DELETE, IPCTNL_MSG_CT_NEW, NFNL_SUBSYS_CTNETLINK,
+    },
+    nfconntrack::nlas::ConnectionNla,
+};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum NfConntrackMessage {
+    ConnectionNew(Vec<ConnectionNla>),
+    ConnectionDelete(Vec<ConnectionNla>),
+    Other {
+        message_type: u8,
+        nlas: Vec<DefaultNla>,
+    },
+}
+
+impl NfConntrackMessage {
+    pub const SUBSYS: u8 = NFNL_SUBSYS_CTNETLINK;
+
+    pub fn message_type(&self) -> u8 {
+        match self {
+            NfConntrackMessage::ConnectionNew(_) => IPCTNL_MSG_CT_NEW,
+            NfConntrackMessage::ConnectionDelete(_) => IPCTNL_MSG_CT_DELETE,
+            NfConntrackMessage::Other { message_type, .. } => *message_type,
+        }
+    }
+}
+
+impl Emitable for NfConntrackMessage {
+    fn buffer_len(&self) -> usize {
+        match self {
+            NfConntrackMessage::ConnectionNew(nlas)
+            | NfConntrackMessage::ConnectionDelete(nlas) => {
+                nlas.as_slice().buffer_len()
+            }
+            NfConntrackMessage::Other { nlas, .. } => {
+                nlas.as_slice().buffer_len()
+            }
+        }
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        match self {
+            NfConntrackMessage::ConnectionNew(nlas)
+            | NfConntrackMessage::ConnectionDelete(nlas) => {
+                nlas.as_slice().emit(buffer)
+            }
+            NfConntrackMessage::Other { nlas, .. } => {
+                nlas.as_slice().emit(buffer)
+            }
+        };
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized>
+    ParseableParametrized<NetfilterBuffer<&'a T>, u8> for NfConntrackMessage
+{
+    fn parse_with_param(
+        buf: &NetfilterBuffer<&'a T>,
+        message_type: u8,
+    ) -> Result<Self, DecodeError> {
+        Ok(match message_type {
+            IPCTNL_MSG_CT_NEW => {
+                let nlas = buf
+                    .parse_all_nlas(|nla_buf| ConnectionNla::parse(&nla_buf))?;
+                NfConntrackMessage::ConnectionNew(nlas)
+            }
+            IPCTNL_MSG_CT_DELETE => {
+                let nlas = buf
+                    .parse_all_nlas(|nla_buf| ConnectionNla::parse(&nla_buf))?;
+                NfConntrackMessage::ConnectionDelete(nlas)
+            }
+            _ => NfConntrackMessage::Other {
+                message_type,
+                nlas: buf.default_nlas()?,
+            },
+        })
+    }
+}

--- a/src/nfconntrack/mod.rs
+++ b/src/nfconntrack/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+mod message;
+pub use message::NfConntrackMessage;
+pub mod nlas;
+
+pub use nlas::ConnectionNla;

--- a/src/nfconntrack/nlas/connection.rs
+++ b/src/nfconntrack/nlas/connection.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+
+use derive_more::IsVariant;
+
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    DecodeError, Parseable,
+};
+
+use crate::{
+    constants::{CTA_TUPLE_ORIG, CTA_TUPLE_REPLY},
+    nfconntrack::nlas::ConnectionTuple,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, IsVariant)]
+pub enum ConnectionNla {
+    TupleOrig(ConnectionTuple),
+    TupleReply(ConnectionTuple),
+    Other(DefaultNla),
+}
+
+impl Nla for ConnectionNla {
+    fn value_len(&self) -> usize {
+        match self {
+            ConnectionNla::TupleOrig(attr) => attr.value_len(),
+            ConnectionNla::TupleReply(attr) => attr.value_len(),
+            ConnectionNla::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            ConnectionNla::TupleOrig(attr) => attr.kind(),
+            ConnectionNla::TupleReply(attr) => attr.kind(),
+            ConnectionNla::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            ConnectionNla::TupleOrig(attr) => attr.emit_value(buffer),
+            ConnectionNla::TupleReply(attr) => attr.emit_value(buffer),
+            ConnectionNla::Other(attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
+    for ConnectionNla
+{
+    fn parse(buf: &NlaBuffer<&'buffer T>) -> Result<Self, DecodeError> {
+        let payload = NlaBuffer::new(buf.value());
+        let nla = match buf.kind() {
+            CTA_TUPLE_ORIG => {
+                ConnectionNla::TupleOrig(ConnectionTuple::parse(&payload)?)
+            }
+            CTA_TUPLE_REPLY => {
+                ConnectionNla::TupleReply(ConnectionTuple::parse(&payload)?)
+            }
+            _ => ConnectionNla::Other(DefaultNla::parse(buf)?),
+        };
+        Ok(nla)
+    }
+}

--- a/src/nfconntrack/nlas/connection_member.rs
+++ b/src/nfconntrack/nlas/connection_member.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+use derive_more::IsVariant;
+
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    DecodeError, Parseable,
+};
+
+use crate::{
+    constants::{CTA_TUPLE_IP, CTA_TUPLE_PROTO},
+    nfconntrack::nlas::{IpTuple, ProtoTuple},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, IsVariant)]
+pub enum ConnectionMember {
+    IpTuple(IpTuple),
+    ProtoTuple(ProtoTuple),
+    Other(DefaultNla),
+}
+
+impl Nla for ConnectionMember {
+    fn value_len(&self) -> usize {
+        match self {
+            ConnectionMember::IpTuple(attr) => attr.value_len(),
+            ConnectionMember::ProtoTuple(attr) => attr.value_len(),
+            ConnectionMember::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            ConnectionMember::IpTuple(attr) => attr.kind(),
+            ConnectionMember::ProtoTuple(attr) => attr.kind(),
+            ConnectionMember::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            ConnectionMember::IpTuple(attr) => attr.emit_value(buffer),
+            ConnectionMember::ProtoTuple(attr) => attr.emit_value(buffer),
+            ConnectionMember::Other(attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
+    for ConnectionMember
+{
+    fn parse(buf: &NlaBuffer<&'buffer T>) -> Result<Self, DecodeError> {
+        let kind = buf.kind();
+        let payload = NlaBuffer::new(buf.value());
+        let nla = match kind {
+            CTA_TUPLE_IP => {
+                ConnectionMember::IpTuple(IpTuple::parse(&payload)?)
+            }
+            CTA_TUPLE_PROTO => {
+                ConnectionMember::ProtoTuple(ProtoTuple::parse(&payload)?)
+            }
+            _ => ConnectionMember::Other(DefaultNla::parse(buf)?),
+        };
+        Ok(nla)
+    }
+}

--- a/src/nfconntrack/nlas/connection_tuple.rs
+++ b/src/nfconntrack/nlas/connection_tuple.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{
+    nla::{Nla, NlaBuffer, NlasIterator},
+    DecodeError, Parseable,
+};
+use std::convert::TryFrom;
+use std::net::IpAddr;
+
+use crate::nfconntrack::nlas::{ConnectionMember, IpMember, ProtoMember};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConnectionTuple(Vec<ConnectionMember>);
+
+impl ConnectionTuple {
+    pub fn iter(&self) -> std::slice::Iter<ConnectionMember> {
+        self.0.iter()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ConnectionProperties {
+    pub src_ip: IpAddr,
+    pub dst_ip: IpAddr,
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub protocol: u8,
+}
+
+impl TryFrom<ConnectionTuple> for ConnectionProperties {
+    type Error = DecodeError;
+
+    fn try_from(cxn_tuple: ConnectionTuple) -> Result<Self, Self::Error> {
+        let mut sip: Option<IpAddr> = None;
+        let mut dip: Option<IpAddr> = None;
+        let mut spt: Option<u16> = None;
+        let mut dpt: Option<u16> = None;
+        let mut prot: Option<u8> = None;
+
+        for member in cxn_tuple.iter() {
+            match member {
+                ConnectionMember::IpTuple(ip_tuple) => {
+                    for ip_mem in ip_tuple.iter() {
+                        match ip_mem {
+                            IpMember::Src(addr) => sip = Some(*addr),
+                            IpMember::Dst(addr) => dip = Some(*addr),
+                        }
+                    }
+                }
+                ConnectionMember::ProtoTuple(proto_tuple) => {
+                    for proto_mem in proto_tuple.iter() {
+                        match proto_mem {
+                            ProtoMember::ProtoNum(p) => prot = Some(*p),
+                            ProtoMember::SrcPort(p) => spt = Some(*p),
+                            ProtoMember::DstPort(p) => dpt = Some(*p),
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match (sip, dip, spt, dpt, prot) {
+            (
+                Some(src_ip),
+                Some(dst_ip),
+                Some(src_port),
+                Some(dst_port),
+                Some(protocol),
+            ) => Ok(ConnectionProperties {
+                src_ip,
+                dst_ip,
+                src_port,
+                dst_port,
+                protocol,
+            }),
+            _ => Err("Connection properties incomplete".into()),
+        }
+    }
+}
+
+impl Nla for ConnectionTuple {
+    fn value_len(&self) -> usize {
+        self.0.iter().map(|c| c.value_len()).sum()
+    }
+
+    fn kind(&self) -> u16 {
+        todo!()
+    }
+
+    fn emit_value(&self, _buffer: &mut [u8]) {
+        todo!()
+    }
+}
+
+impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
+    for ConnectionTuple
+{
+    fn parse(buf: &NlaBuffer<&'buffer T>) -> Result<Self, DecodeError> {
+        let nlas = NlasIterator::new(buf.into_inner())
+            .map(|nla_buf| ConnectionMember::parse(&nla_buf.unwrap()).unwrap())
+            .collect();
+        Ok(ConnectionTuple(nlas))
+    }
+}

--- a/src/nfconntrack/nlas/ip_member.rs
+++ b/src/nfconntrack/nlas/ip_member.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+use derive_more::IsVariant;
+use std::net::IpAddr;
+
+use netlink_packet_utils::{
+    nla::{Nla, NlaBuffer},
+    parsers::parse_ip,
+    DecodeError, Parseable,
+};
+
+use crate::constants::{
+    CTA_IP_V4_DST, CTA_IP_V4_SRC, CTA_IP_V6_DST, CTA_IP_V6_SRC,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, IsVariant)]
+pub enum IpMember {
+    Src(IpAddr),
+    Dst(IpAddr),
+}
+
+impl Nla for IpMember {
+    fn value_len(&self) -> usize {
+        match self {
+            IpMember::Src(addr) | IpMember::Dst(addr) => match addr {
+                IpAddr::V4(_) => 4,
+                IpAddr::V6(_) => 16,
+            },
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            IpMember::Src(addr) => match addr {
+                IpAddr::V4(_) => CTA_IP_V4_SRC,
+                IpAddr::V6(_) => CTA_IP_V6_SRC,
+            },
+            IpMember::Dst(addr) => match addr {
+                IpAddr::V4(_) => CTA_IP_V4_DST,
+                IpAddr::V6(_) => CTA_IP_V6_DST,
+            },
+        }
+    }
+
+    fn emit_value(&self, _buffer: &mut [u8]) {
+        todo!()
+    }
+}
+
+impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
+    for IpMember
+{
+    fn parse(buf: &NlaBuffer<&'buffer T>) -> Result<Self, DecodeError> {
+        let kind = buf.kind();
+        let payload = buf.value();
+        let nla = match kind {
+            CTA_IP_V4_SRC => IpMember::Src(parse_ip(payload)?),
+            CTA_IP_V4_DST => IpMember::Dst(parse_ip(payload)?),
+            CTA_IP_V6_SRC => IpMember::Src(parse_ip(payload)?),
+            CTA_IP_V6_DST => IpMember::Dst(parse_ip(payload)?),
+            _ => return Err(format!("Unhandled IP type: {}", kind).into()),
+        };
+        Ok(nla)
+    }
+}

--- a/src/nfconntrack/nlas/ip_tuple.rs
+++ b/src/nfconntrack/nlas/ip_tuple.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{
+    nla::{Nla, NlaBuffer, NlasIterator},
+    DecodeError, Parseable,
+};
+
+use crate::nfconntrack::nlas::IpMember;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IpTuple(Vec<IpMember>);
+
+impl IpTuple {
+    pub fn iter(&self) -> std::slice::Iter<IpMember> {
+        self.0.iter()
+    }
+}
+
+impl Nla for IpTuple {
+    fn value_len(&self) -> usize {
+        self.0.iter().map(|c| c.value_len()).sum()
+    }
+
+    fn kind(&self) -> u16 {
+        todo!()
+    }
+
+    fn emit_value(&self, _buffer: &mut [u8]) {
+        todo!()
+    }
+}
+
+impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
+    for IpTuple
+{
+    fn parse(buf: &NlaBuffer<&'buffer T>) -> Result<Self, DecodeError> {
+        let nlas = NlasIterator::new(buf.into_inner())
+            .map(|nla_buf| IpMember::parse(&nla_buf.unwrap()).unwrap())
+            .collect();
+        Ok(IpTuple(nlas))
+    }
+}

--- a/src/nfconntrack/nlas/mod.rs
+++ b/src/nfconntrack/nlas/mod.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pub mod connection;
+pub use connection::ConnectionNla;
+pub mod connection_member;
+pub use connection_member::ConnectionMember;
+pub mod connection_tuple;
+pub use connection_tuple::ConnectionProperties;
+pub use connection_tuple::ConnectionTuple;
+pub mod ip_member;
+pub use ip_member::IpMember;
+pub mod ip_tuple;
+pub use ip_tuple::IpTuple;
+pub mod proto_member;
+pub use proto_member::ProtoMember;
+pub mod proto_tuple;
+pub use proto_tuple::ProtoTuple;

--- a/src/nfconntrack/nlas/proto_member.rs
+++ b/src/nfconntrack/nlas/proto_member.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use derive_more::IsVariant;
+
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    parsers::{parse_u16_be, parse_u8},
+    DecodeError, Parseable,
+};
+
+use crate::constants::{CTA_PROTO_DST_PORT, CTA_PROTO_NUM, CTA_PROTO_SRC_PORT};
+
+#[derive(Clone, Debug, PartialEq, Eq, IsVariant)]
+pub enum ProtoMember {
+    ProtoNum(u8),
+    SrcPort(u16),
+    DstPort(u16),
+    Other(DefaultNla),
+}
+
+impl Nla for ProtoMember {
+    fn value_len(&self) -> usize {
+        match self {
+            ProtoMember::ProtoNum(_) => 1,
+            ProtoMember::SrcPort(_) => 2,
+            ProtoMember::DstPort(_) => 2,
+            ProtoMember::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            ProtoMember::ProtoNum(_) => CTA_PROTO_NUM,
+            ProtoMember::SrcPort(_) => CTA_PROTO_SRC_PORT,
+            ProtoMember::DstPort(_) => CTA_PROTO_DST_PORT,
+            ProtoMember::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, _buffer: &mut [u8]) {
+        todo!()
+    }
+}
+
+impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
+    for ProtoMember
+{
+    fn parse(buf: &NlaBuffer<&'buffer T>) -> Result<Self, DecodeError> {
+        let kind = buf.kind();
+        let payload = buf.value();
+        let nla = match kind {
+            CTA_PROTO_NUM => ProtoMember::ProtoNum(
+                parse_u8(payload).context("invalid CTA_PROTO_NUM value")?,
+            ),
+            CTA_PROTO_SRC_PORT => ProtoMember::SrcPort(
+                parse_u16_be(payload)
+                    .context("invalid CTA_PROTO_SRC_PORT value")?,
+            ),
+            CTA_PROTO_DST_PORT => ProtoMember::DstPort(
+                parse_u16_be(payload)
+                    .context("invalid CTA_PROTO_DST_PORT value")?,
+            ),
+            _ => ProtoMember::Other(DefaultNla::parse(buf)?),
+        };
+        Ok(nla)
+    }
+}

--- a/src/nfconntrack/nlas/proto_tuple.rs
+++ b/src/nfconntrack/nlas/proto_tuple.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_utils::{
+    nla::{Nla, NlaBuffer, NlasIterator},
+    DecodeError, Parseable,
+};
+
+use crate::nfconntrack::nlas::ProtoMember;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtoTuple(Vec<ProtoMember>);
+
+impl ProtoTuple {
+    pub fn iter(&self) -> std::slice::Iter<ProtoMember> {
+        self.0.iter()
+    }
+}
+
+impl Nla for ProtoTuple {
+    fn value_len(&self) -> usize {
+        self.0.iter().map(|c| c.value_len()).sum()
+    }
+
+    fn kind(&self) -> u16 {
+        todo!()
+    }
+
+    fn emit_value(&self, _buffer: &mut [u8]) {
+        todo!()
+    }
+}
+
+impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
+    for ProtoTuple
+{
+    fn parse(buf: &NlaBuffer<&'buffer T>) -> Result<Self, DecodeError> {
+        let nlas = NlasIterator::new(buf.into_inner())
+            .map(|nla_buf| ProtoMember::parse(&nla_buf.unwrap()).unwrap())
+            .collect();
+        Ok(ProtoTuple(nlas))
+    }
+}


### PR DESCRIPTION
This change adds support for the conntrack events of addition and removal.  This allows a calling program to use either a blocking or a non-blocking socket to periodically learn of conntrack activity.

A demonstration of usage is shown in the example program added at `examples/nfconntrack.rs`.