### PR TITLE
Use netlink-packet-core 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,7 @@ repository = "https://github.com/rust-netlink/netlink-packet-netfilter"
 description = "netlink packet types for the netfilter subprotocol"
 
 [dependencies]
-anyhow = "1.0.32"
-byteorder = "1.3.4"
-netlink-packet-core = { version = "0.7.0" }
-netlink-packet-utils = { version = "0.5.1" }
+netlink-packet-core = { version = "0.8.1" }
 bitflags = "2.3"
 libc = "0.2.77"
 derive_more = "0.99.16"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,11 +7,9 @@ use crate::{
     },
     nflog::NfLogMessage,
 };
-use anyhow::Context;
-use netlink_packet_utils::{
-    buffer,
-    nla::{DefaultNla, NlaBuffer, NlasIterator},
-    DecodeError, Parseable, ParseableParametrized,
+use netlink_packet_core::{
+    buffer, fields, DecodeError, DefaultNla, ErrorContext, NlaBuffer,
+    NlasIterator, Parseable, ParseableParametrized,
 };
 
 buffer!(NetfilterBuffer(NETFILTER_HEADER_LEN) {
@@ -30,11 +28,10 @@ impl<'a, T: AsRef<[u8]> + ?Sized> NetfilterBuffer<&'a T> {
     where
         F: Fn(NlaBuffer<&[u8]>) -> Result<U, DecodeError>,
     {
-        Ok(self
-            .nlas()
+        self.nlas()
             .map(|buf| f(buf?))
             .collect::<Result<Vec<_>, _>>()
-            .context("failed to parse NLAs")?)
+            .context("failed to parse NLAs")
     }
 
     pub fn default_nlas(&self) -> Result<Vec<DefaultNla>, DecodeError> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-pub use netlink_packet_core::constants::*;
-
 pub const AF_UNSPEC: u8 = libc::AF_UNSPEC as u8;
 pub const AF_UNIX: u8 = libc::AF_UNIX as u8;
 pub const AF_LOCAL: u8 = libc::AF_LOCAL as u8;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, DefaultNla, Emitable,
     NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
-};
-use netlink_packet_utils::{
-    buffer, nla::DefaultNla, DecodeError, Emitable, Parseable,
-    ParseableParametrized,
+    Parseable, ParseableParametrized,
 };
 
 use crate::{buffer::NetfilterBuffer, nflog::NfLogMessage};

--- a/src/nflog/message.rs
+++ b/src/nflog/message.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{
-    nla::DefaultNla, DecodeError, Emitable, Parseable, ParseableParametrized,
+use netlink_packet_core::{
+    DecodeError, DefaultNla, Emitable, Parseable, ParseableParametrized,
 };
 
 use crate::{

--- a/src/nflog/nlas/config/config_cmd.rs
+++ b/src/nflog/nlas/config/config_cmd.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::nla::Nla;
+use netlink_packet_core::Nla;
 
 const NFULA_CFG_CMD: u16 = libc::NFULA_CFG_CMD as u16;
 const NFULNL_CFG_CMD_NONE: u8 = libc::NFULNL_CFG_CMD_NONE as u8;

--- a/src/nflog/nlas/config/config_flags.rs
+++ b/src/nflog/nlas/config/config_flags.rs
@@ -3,8 +3,7 @@
 use std::mem::size_of;
 
 use bitflags::bitflags;
-use byteorder::{BigEndian, ByteOrder};
-use netlink_packet_utils::nla::Nla;
+use netlink_packet_core::{emit_u16_be, Nla};
 
 const NFULA_CFG_FLAGS: u16 = libc::NFULA_CFG_FLAGS as u16;
 
@@ -34,6 +33,6 @@ impl Nla for ConfigFlags {
     }
 
     fn emit_value(&self, buffer: &mut [u8]) {
-        BigEndian::write_u16(buffer, self.bits());
+        emit_u16_be(buffer, self.bits()).unwrap();
     }
 }

--- a/src/nflog/nlas/config/config_mode.rs
+++ b/src/nflog/nlas/config/config_mode.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{buffer, errors::DecodeError, nla::Nla, Parseable};
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Nla, Parseable,
+};
 
 const NFULA_CFG_MODE: u16 = libc::NFULA_CFG_MODE as u16;
 const NFULNL_COPY_NONE: u8 = libc::NFULNL_COPY_NONE as u8;

--- a/src/nflog/nlas/config/nla.rs
+++ b/src/nflog/nlas/config/nla.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use byteorder::{BigEndian, ByteOrder};
 use derive_more::{From, IsVariant};
-use netlink_packet_utils::{
-    nla::{DefaultNla, Nla, NlaBuffer},
-    parsers::{parse_u16_be, parse_u32_be, parse_u8},
-    DecodeError, Parseable,
+use netlink_packet_core::{
+    emit_u32_be, parse_u16_be, parse_u32_be, parse_u8, DecodeError, DefaultNla,
+    ErrorContext, Nla, NlaBuffer, Parseable,
 };
 
 use crate::{
@@ -63,11 +60,11 @@ impl Nla for ConfigNla {
             ConfigNla::Cmd(attr) => attr.emit_value(buffer),
             ConfigNla::Mode(attr) => attr.emit_value(buffer),
             ConfigNla::NlBufSiz(buf_siz) => {
-                BigEndian::write_u32(buffer, *buf_siz)
+                emit_u32_be(buffer, *buf_siz).unwrap();
             }
             ConfigNla::Timeout(attr) => attr.emit_value(buffer),
             ConfigNla::QThresh(q_thresh) => {
-                BigEndian::write_u32(buffer, *q_thresh)
+                emit_u32_be(buffer, *q_thresh).unwrap();
             }
             ConfigNla::Flags(attr) => attr.emit_value(buffer),
             ConfigNla::Other(attr) => attr.emit_value(buffer),

--- a/src/nflog/nlas/config/timeout.rs
+++ b/src/nflog/nlas/config/timeout.rs
@@ -2,8 +2,7 @@
 
 use std::{convert::TryInto, mem::size_of, time::Duration};
 
-use byteorder::{BigEndian, ByteOrder};
-use netlink_packet_utils::nla::Nla;
+use netlink_packet_core::{emit_u32_be, Nla};
 
 const NFULA_CFG_TIMEOUT: u16 = libc::NFULA_CFG_TIMEOUT as u16;
 
@@ -36,6 +35,6 @@ impl Nla for Timeout {
     }
 
     fn emit_value(&self, buffer: &mut [u8]) {
-        BigEndian::write_u32(buffer, self.hundredth);
+        emit_u32_be(buffer, self.hundredth).unwrap();
     }
 }

--- a/src/nflog/nlas/packet/hw_addr.rs
+++ b/src/nflog/nlas/packet/hw_addr.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{buffer, nla::Nla, DecodeError, Parseable};
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Nla, Parseable,
+};
 
 use crate::constants::NFULA_HWADDR;
 

--- a/src/nflog/nlas/packet/packet_hdr.rs
+++ b/src/nflog/nlas/packet/packet_hdr.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{buffer, nla::Nla, DecodeError, Parseable};
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Nla, Parseable,
+};
 
 const PACKET_HDR_LEN: usize = 4;
 pub const NFULA_PACKET_HDR: u16 = libc::NFULA_PACKET_HDR as u16;

--- a/src/nflog/nlas/packet/timestamp.rs
+++ b/src/nflog/nlas/packet/timestamp.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::{buffer, nla::Nla, DecodeError, Parseable};
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Nla, Parseable,
+};
 
 use crate::constants::NFULA_TIMESTAMP;
 


### PR DESCRIPTION
The netlink-packet-netfilter crate currently uses netlink-packet-utils which is deprecated in favor of netlink-packet-core. 

The anyhow and byteorder crate are also replaced in favor of netlink-packet-core.