### PR TITLE
feat: Add support for deleting conntrack entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "netlink packet types for the netfilter subprotocol"
 
 [dependencies]
 netlink-packet-core = { version = "0.8.1" }
-bitflags = "2.3"
+bitflags = "2.10.0"
 libc = "0.2.77"
 derive_more = "0.99.16"
 

--- a/examples/dump_conntrack.rs
+++ b/examples/dump_conntrack.rs
@@ -4,8 +4,7 @@ use netlink_packet_core::{
     NetlinkHeader, NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST,
 };
 use netlink_packet_netfilter::{
-    conntrack::ConntrackMessage, constants::AF_INET, NetfilterHeader,
-    NetfilterMessage,
+    conntrack::ConntrackMessage, NetfilterHeader, NetfilterMessage, ProtoFamily,
 };
 use netlink_sys::{protocols::NETLINK_NETFILTER, Socket, SocketAddr};
 
@@ -19,7 +18,7 @@ fn main() {
     let mut packet = NetlinkMessage::new(
         nl_hdr,
         NetlinkPayload::from(NetfilterMessage::new(
-            NetfilterHeader::new(AF_INET, 0, 0),
+            NetfilterHeader::new(ProtoFamily::IPv4, 0, 0),
             ConntrackMessage::Get(vec![]),
         )),
     );

--- a/examples/nflog.rs
+++ b/examples/nflog.rs
@@ -6,11 +6,10 @@
 //   2) build the example: cargo build --example nflog
 //   3) run it as root: sudo ../target/debug/examples/nflog
 
-use std::{net::Ipv4Addr, time::Duration};
+use std::time::Duration;
 
 use netlink_packet_core::{parse_ip, NetlinkMessage, NetlinkPayload};
 use netlink_packet_netfilter::{
-    constants::*,
     nflog::{
         config_request,
         nlas::{
@@ -19,7 +18,7 @@ use netlink_packet_netfilter::{
         },
         ULogMessage,
     },
-    NetfilterMessage, NetfilterMessageInner,
+    NetfilterMessage, NetfilterMessageInner, ProtoFamily,
 };
 use netlink_sys::{constants::NETLINK_NETFILTER, Socket};
 
@@ -43,7 +42,8 @@ fn main() {
     socket.bind_auto().unwrap();
 
     // Then we issue the PfBind command
-    let packet = config_request(AF_INET, 0, vec![ConfigCmd::PfBind.into()]);
+    let packet =
+        config_request(ProtoFamily::IPv4, 0, vec![ConfigCmd::PfBind.into()]);
     let mut buf = vec![0; packet.header.length as usize];
     packet.serialize(&mut buf[..]);
     println!(">>> {:?}", packet);
@@ -64,7 +64,7 @@ fn main() {
     // also set various parameters at the same time
     let timeout: Timeout = Duration::from_millis(100).into();
     let packet = config_request(
-        AF_INET,
+        ProtoFamily::IPv4,
         1,
         vec![
             ConfigCmd::Bind.into(),

--- a/src/conntrack/attributes/attribute.rs
+++ b/src/conntrack/attributes/attribute.rs
@@ -1,20 +1,30 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
-    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
-    NlasIterator, Parseable,
+    emit_u32_be, parse_u32_be, DecodeError, DefaultNla, Emitable, ErrorContext,
+    Nla, NlaBuffer, NlasIterator, Parseable,
 };
 
-use crate::conntrack::attributes::{protoinfo::ProtoInfo, tuple::Tuple};
+use crate::conntrack::attributes::{
+    protoinfo::ProtoInfo, status::Status, tuple::Tuple,
+};
 
 const CTA_TUPLE_ORIG: u16 = 1;
+const CTA_TUPLE_REPLY: u16 = 2;
 const CTA_PROTOINFO: u16 = 4;
+const CTA_STATUS: u16 = 3;
+const CTA_TIMEOUT: u16 = 7;
+const CTA_MARK: u16 = 8;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ConntrackAttribute {
     CtaTupleOrig(Vec<Tuple>),
+    CtaTupleReply(Vec<Tuple>),
     CtaProtoInfo(Vec<ProtoInfo>),
+    CtaStatus(Status),
+    CtaTimeout(u32),
+    CtaMark(u32),
     Other(DefaultNla),
 }
 
@@ -24,9 +34,15 @@ impl Nla for ConntrackAttribute {
             ConntrackAttribute::CtaTupleOrig(attr) => {
                 attr.iter().map(|op| op.buffer_len()).sum()
             }
+            ConntrackAttribute::CtaTupleReply(attr) => {
+                attr.iter().map(|op| op.buffer_len()).sum()
+            }
             ConntrackAttribute::CtaProtoInfo(attr) => {
                 attr.iter().map(|op| op.buffer_len()).sum()
             }
+            ConntrackAttribute::CtaStatus(_) => size_of::<u32>(),
+            ConntrackAttribute::CtaTimeout(attr) => size_of_val(attr),
+            ConntrackAttribute::CtaMark(attr) => size_of_val(attr),
             ConntrackAttribute::Other(attr) => attr.value_len(),
         }
     }
@@ -34,7 +50,11 @@ impl Nla for ConntrackAttribute {
     fn kind(&self) -> u16 {
         match self {
             ConntrackAttribute::CtaTupleOrig(_) => CTA_TUPLE_ORIG,
+            ConntrackAttribute::CtaTupleReply(_) => CTA_TUPLE_REPLY,
             ConntrackAttribute::CtaProtoInfo(_) => CTA_PROTOINFO,
+            ConntrackAttribute::CtaStatus(_) => CTA_STATUS,
+            ConntrackAttribute::CtaTimeout(_) => CTA_TIMEOUT,
+            ConntrackAttribute::CtaMark(_) => CTA_MARK,
             ConntrackAttribute::Other(attr) => attr.kind(),
         }
     }
@@ -48,12 +68,28 @@ impl Nla for ConntrackAttribute {
                     len += op.buffer_len();
                 }
             }
+            ConntrackAttribute::CtaTupleReply(attr) => {
+                let mut len = 0;
+                for op in attr {
+                    op.emit(&mut buffer[len..]);
+                    len += op.buffer_len();
+                }
+            }
             ConntrackAttribute::CtaProtoInfo(attr) => {
                 let mut len = 0;
                 for op in attr {
                     op.emit(&mut buffer[len..]);
                     len += op.buffer_len();
                 }
+            }
+            ConntrackAttribute::CtaStatus(attr) => {
+                emit_u32_be(buffer, (*attr).bits()).unwrap()
+            }
+            ConntrackAttribute::CtaTimeout(attr) => {
+                emit_u32_be(buffer, *attr).unwrap()
+            }
+            ConntrackAttribute::CtaMark(attr) => {
+                emit_u32_be(buffer, *attr).unwrap()
             }
             ConntrackAttribute::Other(attr) => attr.emit_value(buffer),
         }
@@ -62,6 +98,7 @@ impl Nla for ConntrackAttribute {
         matches!(
             self,
             ConntrackAttribute::CtaTupleOrig(_)
+                | ConntrackAttribute::CtaTupleReply(_)
                 | ConntrackAttribute::CtaProtoInfo(_)
         )
     }
@@ -82,6 +119,16 @@ impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
                 }
                 ConntrackAttribute::CtaTupleOrig(tuples)
             }
+            CTA_TUPLE_REPLY => {
+                let mut tuples = Vec::new();
+                for nlas in NlasIterator::new(payload) {
+                    let nlas =
+                        &nlas.context("invalid CTA_TUPLE_REPLY value")?;
+
+                    tuples.push(Tuple::parse(nlas)?);
+                }
+                ConntrackAttribute::CtaTupleReply(tuples)
+            }
             CTA_PROTOINFO => {
                 let mut proto_infos = Vec::new();
                 for nlas in NlasIterator::new(payload) {
@@ -90,6 +137,18 @@ impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'buffer T>>
                 }
                 ConntrackAttribute::CtaProtoInfo(proto_infos)
             }
+            CTA_STATUS => {
+                ConntrackAttribute::CtaStatus(Status::from_bits_retain(
+                    parse_u32_be(payload)
+                        .context("invalid CTA_STATUS value")?,
+                ))
+            }
+            CTA_TIMEOUT => ConntrackAttribute::CtaTimeout(
+                parse_u32_be(payload).context("invalid CTA_TIMEOUT value")?,
+            ),
+            CTA_MARK => ConntrackAttribute::CtaMark(
+                parse_u32_be(payload).context("invalid CTA_MARK value")?,
+            ),
             _ => ConntrackAttribute::Other(DefaultNla::parse(buf)?),
         };
         Ok(nla)

--- a/src/conntrack/attributes/mod.rs
+++ b/src/conntrack/attributes/mod.rs
@@ -5,6 +5,7 @@ mod iptuple;
 mod protoinfo;
 mod protoinfotcp;
 mod prototuple;
+mod status;
 mod tcp_flags;
 mod tuple;
 
@@ -13,5 +14,6 @@ pub use iptuple::IPTuple;
 pub use protoinfo::ProtoInfo;
 pub use protoinfotcp::ProtoInfoTCP;
 pub use prototuple::{ProtoTuple, Protocol};
+pub use status::Status;
 pub use tcp_flags::TCPFlags;
 pub use tuple::Tuple;

--- a/src/conntrack/attributes/status.rs
+++ b/src/conntrack/attributes/status.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+use bitflags::bitflags;
+
+// Conntrack status flags from uapi/linux/netfilter/nf_conntrack_common.h
+const IPS_EXPECTED: u32 = 1;
+const IPS_SEEN_REPLY: u32 = 1 << 1;
+const IPS_ASSURED: u32 = 1 << 2;
+const IPS_CONFIRMED: u32 = 1 << 3;
+const IPS_SRC_NAT: u32 = 1 << 4;
+const IPS_DST_NAT: u32 = 1 << 5;
+const IPS_SEQ_ADJUST: u32 = 1 << 6;
+const IPS_SRC_NAT_DONE: u32 = 1 << 7;
+const IPS_DST_NAT_DONE: u32 = 1 << 8;
+const IPS_DYING: u32 = 1 << 9;
+const IPS_FIXED_TIMEOUT: u32 = 1 << 10;
+const IPS_TEMPLATE: u32 = 1 << 11;
+const IPS_UNTRACKED: u32 = 1 << 12;
+const IPS_HELPER: u32 = 1 << 13;
+const IPS_OFFLOAD: u32 = 1 << 14;
+
+const IPS_NAT_MASK: u32 = IPS_SRC_NAT | IPS_DST_NAT;
+const IPS_NAT_DONE_MASK: u32 = IPS_SRC_NAT_DONE | IPS_DST_NAT_DONE;
+
+bitflags! {
+    #[non_exhaustive]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Status: u32 {
+        const Expected      = IPS_EXPECTED;
+        const SeenReply     = IPS_SEEN_REPLY;
+        const Assured       = IPS_ASSURED;
+        const Confirmed     = IPS_CONFIRMED;
+        const SrcNat        = IPS_SRC_NAT;
+        const DstNat        = IPS_DST_NAT;
+        const SeqAdjust     = IPS_SEQ_ADJUST;
+        const SrcNatDone    = IPS_SRC_NAT_DONE;
+        const DstNatDone    = IPS_DST_NAT_DONE;
+        const Dying         = IPS_DYING;
+        const FixedTimeout  = IPS_FIXED_TIMEOUT;
+        const Template      = IPS_TEMPLATE;
+        const Untracked     = IPS_UNTRACKED;
+        const Helper        = IPS_HELPER;
+        const Offload       = IPS_OFFLOAD;
+        const NatMask       = IPS_NAT_MASK;
+        const NatDoneMask   = IPS_NAT_DONE_MASK;
+        const _ = !0;
+    }
+}

--- a/src/conntrack/mod.rs
+++ b/src/conntrack/mod.rs
@@ -5,5 +5,5 @@ pub use message::{ConntrackMessage, ConntrackMessageType};
 mod attributes;
 pub use attributes::{
     ConntrackAttribute, IPTuple, ProtoInfo, ProtoInfoTCP, ProtoTuple, Protocol,
-    TCPFlags, Tuple,
+    Status, TCPFlags, Tuple,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@ pub(crate) mod buffer;
 pub mod constants;
 mod message;
 pub use message::{
-    NetfilterHeader, NetfilterMessage, NetfilterMessageInner, Subsystem,
+    NetfilterHeader, NetfilterMessage, NetfilterMessageInner, ProtoFamily,
+    Subsystem,
 };
 pub mod conntrack;
 pub mod nflog;

--- a/src/nflog/mod.rs
+++ b/src/nflog/mod.rs
@@ -9,12 +9,12 @@ use netlink_packet_core::{
 };
 
 use crate::{
-    constants::NFNETLINK_V0, nflog::nlas::config::ConfigNla, NetfilterHeader,
-    NetfilterMessage,
+    constants::NFNETLINK_V0, message::ProtoFamily,
+    nflog::nlas::config::ConfigNla, NetfilterHeader, NetfilterMessage,
 };
 
 pub fn config_request(
-    family: u8,
+    family: ProtoFamily,
     group_num: u16,
     nlas: Vec<ConfigNla>,
 ) -> NetlinkMessage<NetfilterMessage> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,10 +8,9 @@ use crate::{
     buffer::NetfilterBuffer,
     conntrack::{
         ConntrackAttribute, ConntrackMessage, ConntrackMessageType, IPTuple,
-        ProtoInfo, ProtoInfoTCP, ProtoTuple, Protocol, TCPFlags, Tuple,
+        ProtoInfo, ProtoInfoTCP, ProtoTuple, Protocol, Status, TCPFlags, Tuple,
     },
-    constants::{AF_INET, AF_INET6, AF_UNSPEC},
-    message::Subsystem,
+    message::{ProtoFamily, Subsystem},
     NetfilterHeader, NetfilterMessage,
 };
 
@@ -22,7 +21,7 @@ fn test_dump_conntrack() {
     let raw: Vec<u8> = vec![0x00, 0x00, 0x00, 0x00];
 
     let expected: NetfilterMessage = NetfilterMessage::new(
-        NetfilterHeader::new(AF_UNSPEC, 0, 0),
+        NetfilterHeader::new(ProtoFamily::Unspec, 0, 0),
         ConntrackMessage::Get(vec![]),
     );
 
@@ -90,7 +89,7 @@ fn test_get_conntrack_tcp_ipv4() {
     ];
 
     let expected: NetfilterMessage = NetfilterMessage::new(
-        NetfilterHeader::new(AF_INET, 0, 0),
+        NetfilterHeader::new(ProtoFamily::IPv4, 0, 0),
         ConntrackMessage::Get(attributes),
     );
 
@@ -148,7 +147,7 @@ fn test_get_conntrack_udp_ipv6() {
     ])];
 
     let expected: NetfilterMessage = NetfilterMessage::new(
-        NetfilterHeader::new(AF_INET6, 0, 0),
+        NetfilterHeader::new(ProtoFamily::IPv6, 0, 0),
         ConntrackMessage::Get(attributes),
     );
 
@@ -160,6 +159,212 @@ fn test_get_conntrack_udp_ipv6() {
 
     let message_type = ((u8::from(Subsystem::Conntrack) as u16) << 8)
         | (u8::from(ConntrackMessageType::Get) as u16);
+    // Check if the deserialization was correct
+    assert_eq!(
+        NetfilterMessage::parse_with_param(
+            &NetfilterBuffer::new(&raw),
+            message_type
+        )
+        .unwrap(),
+        expected
+    );
+}
+
+// wireshark capture of nlmon against command (netlink message header removed):
+// conntrack -D -f ipv4 -p tcp --src 10.255.160.124 --sport 39640 --dst
+// 140.82.113.26 --dport 443 NOTE: For filtered deletions, conntrack-tools
+// issues a dump request to retrieve all conntrack entries, filters them in
+// userspace, and then sends delete requests for the matching entries with the
+// required attributes.
+#[test]
+fn test_delete_conntrack_tcp_ipv4() {
+    let raw: Vec<u8> = vec![
+        0x02, 0x00, 0x00, 0x00, 0x34, 0x00, 0x01, 0x80, 0x14, 0x00, 0x01, 0x80,
+        0x08, 0x00, 0x01, 0x00, 0x0a, 0xff, 0xa0, 0x7c, 0x08, 0x00, 0x02, 0x00,
+        0x8c, 0x52, 0x71, 0x1a, 0x1c, 0x00, 0x02, 0x80, 0x05, 0x00, 0x01, 0x00,
+        0x06, 0x00, 0x00, 0x00, 0x06, 0x00, 0x02, 0x00, 0x9a, 0xd8, 0x00, 0x00,
+        0x06, 0x00, 0x03, 0x00, 0x01, 0xbb, 0x00, 0x00, 0x34, 0x00, 0x02, 0x80,
+        0x14, 0x00, 0x01, 0x80, 0x08, 0x00, 0x01, 0x00, 0x8c, 0x52, 0x71, 0x1a,
+        0x08, 0x00, 0x02, 0x00, 0x0a, 0xff, 0xa0, 0x7c, 0x1c, 0x00, 0x02, 0x80,
+        0x05, 0x00, 0x01, 0x00, 0x06, 0x00, 0x00, 0x00, 0x06, 0x00, 0x02, 0x00,
+        0x01, 0xbb, 0x00, 0x00, 0x06, 0x00, 0x03, 0x00, 0x9a, 0xd8, 0x00, 0x00,
+        0x08, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x8e, 0x08, 0x00, 0x07, 0x00,
+        0x00, 0x06, 0x97, 0x77, 0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x30, 0x00, 0x04, 0x80, 0x2c, 0x00, 0x01, 0x80, 0x05, 0x00, 0x01, 0x00,
+        0x03, 0x00, 0x00, 0x00, 0x06, 0x00, 0x04, 0x00, 0x23, 0x00, 0x00, 0x00,
+        0x06, 0x00, 0x05, 0x00, 0x23, 0x00, 0x00, 0x00, 0x05, 0x00, 0x02, 0x00,
+        0x0a, 0x00, 0x00, 0x00, 0x05, 0x00, 0x03, 0x00, 0x0a, 0x00, 0x00, 0x00,
+    ];
+
+    let orig_src_addr =
+        IPTuple::SourceAddress(IpAddr::V4("10.255.160.124".parse().unwrap()));
+    let orig_dst_addr = IPTuple::DestinationAddress(IpAddr::V4(
+        "140.82.113.26".parse().unwrap(),
+    ));
+
+    let orig_proto_num = ProtoTuple::Protocol(Protocol::Tcp);
+    let orig_src_port = ProtoTuple::SourcePort(39640);
+    let orig_dst_port = ProtoTuple::DestinationPort(443);
+
+    let orig_ip_tuple = Tuple::Ip(vec![orig_src_addr, orig_dst_addr]);
+    let orig_proto_tuple =
+        Tuple::Proto(vec![orig_proto_num, orig_src_port, orig_dst_port]);
+
+    let reply_src_addr =
+        IPTuple::SourceAddress(IpAddr::V4("140.82.113.26".parse().unwrap()));
+    let reply_dst_addr = IPTuple::DestinationAddress(IpAddr::V4(
+        "10.255.160.124".parse().unwrap(),
+    ));
+
+    let reply_proto_num = ProtoTuple::Protocol(Protocol::Tcp);
+    let reply_src_port = ProtoTuple::SourcePort(443);
+    let reply_dst_port = ProtoTuple::DestinationPort(39640);
+
+    let reply_ip_tuple = Tuple::Ip(vec![reply_src_addr, reply_dst_addr]);
+    let reply_proto_tuple =
+        Tuple::Proto(vec![reply_proto_num, reply_src_port, reply_dst_port]);
+
+    let status = Status::DstNatDone
+        | Status::SrcNatDone
+        | Status::Confirmed
+        | Status::Assured
+        | Status::SeenReply;
+
+    let timeout = 431991;
+    let mark = 0;
+
+    let proto_info = vec![ProtoInfo::TCP(vec![
+        ProtoInfoTCP::State(3),
+        ProtoInfoTCP::OriginalFlags(TCPFlags { flags: 35, mask: 0 }),
+        ProtoInfoTCP::ReplyFlags(TCPFlags { flags: 35, mask: 0 }),
+        ProtoInfoTCP::OriginalWindowScale(10),
+        ProtoInfoTCP::ReplyWindowScale(10),
+    ])];
+
+    let attributes = vec![
+        ConntrackAttribute::CtaTupleOrig(vec![orig_ip_tuple, orig_proto_tuple]),
+        ConntrackAttribute::CtaTupleReply(vec![
+            reply_ip_tuple,
+            reply_proto_tuple,
+        ]),
+        ConntrackAttribute::CtaStatus(status),
+        ConntrackAttribute::CtaTimeout(timeout),
+        ConntrackAttribute::CtaMark(mark),
+        ConntrackAttribute::CtaProtoInfo(proto_info),
+    ];
+
+    let expected: NetfilterMessage = NetfilterMessage::new(
+        NetfilterHeader::new(ProtoFamily::IPv4, 0, 0),
+        ConntrackMessage::Delete(attributes),
+    );
+
+    let mut buffer = vec![0; expected.buffer_len()];
+    expected.emit(&mut buffer);
+
+    // Check if the serialization was correct
+    assert_eq!(buffer, raw);
+
+    let message_type = ((u8::from(Subsystem::Conntrack) as u16) << 8)
+        | (u8::from(ConntrackMessageType::Delete) as u16);
+    // Check if the deserialization was correct
+    assert_eq!(
+        NetfilterMessage::parse_with_param(
+            &NetfilterBuffer::new(&raw),
+            message_type
+        )
+        .unwrap(),
+        expected
+    );
+}
+// wireshark capture of nlmon against command (netlink message header removed):
+// conntrack -D -f ipv6 -p udp --src 2409:40c4:2c:433d:8a2b:74e7:61f9:d824
+// --sport 36289 --dst 2404:6800:4007:839::200a --dport 443 NOTE: For filtered
+// deletions, conntrack-tools issues a dump request to retrieve all conntrack
+// entries, filters them in userspace, and then sends delete requests for the
+// matching entries with the required attributes.
+#[test]
+fn test_delete_conntrack_udp_ipv6() {
+    let raw: Vec<u8> = vec![
+        0x0a, 0x00, 0x00, 0x00, 0x4c, 0x00, 0x01, 0x80, 0x2c, 0x00, 0x01, 0x80,
+        0x14, 0x00, 0x03, 0x00, 0x24, 0x09, 0x40, 0xc4, 0x00, 0x2c, 0x43, 0x3d,
+        0x8a, 0x2b, 0x74, 0xe7, 0x61, 0xf9, 0xd8, 0x24, 0x14, 0x00, 0x04, 0x00,
+        0x24, 0x04, 0x68, 0x00, 0x40, 0x07, 0x08, 0x39, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x20, 0x0a, 0x1c, 0x00, 0x02, 0x80, 0x05, 0x00, 0x01, 0x00,
+        0x11, 0x00, 0x00, 0x00, 0x06, 0x00, 0x02, 0x00, 0x8d, 0xc1, 0x00, 0x00,
+        0x06, 0x00, 0x03, 0x00, 0x01, 0xbb, 0x00, 0x00, 0x4c, 0x00, 0x02, 0x80,
+        0x2c, 0x00, 0x01, 0x80, 0x14, 0x00, 0x03, 0x00, 0x24, 0x04, 0x68, 0x00,
+        0x40, 0x07, 0x08, 0x39, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x0a,
+        0x14, 0x00, 0x04, 0x00, 0x24, 0x09, 0x40, 0xc4, 0x00, 0x2c, 0x43, 0x3d,
+        0x8a, 0x2b, 0x74, 0xe7, 0x61, 0xf9, 0xd8, 0x24, 0x1c, 0x00, 0x02, 0x80,
+        0x05, 0x00, 0x01, 0x00, 0x11, 0x00, 0x00, 0x00, 0x06, 0x00, 0x02, 0x00,
+        0x01, 0xbb, 0x00, 0x00, 0x06, 0x00, 0x03, 0x00, 0x8d, 0xc1, 0x00, 0x00,
+        0x08, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x8e, 0x08, 0x00, 0x07, 0x00,
+        0x00, 0x00, 0x00, 0x73, 0x08, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    let orig_src_addr = IPTuple::SourceAddress(IpAddr::V6(
+        "2409:40c4:2c:433d:8a2b:74e7:61f9:d824".parse().unwrap(),
+    ));
+    let orig_dst_addr = IPTuple::DestinationAddress(IpAddr::V6(
+        "2404:6800:4007:839::200a".parse().unwrap(),
+    ));
+
+    let orig_proto_num = ProtoTuple::Protocol(Protocol::Udp);
+    let orig_src_port = ProtoTuple::SourcePort(36289);
+    let orig_dst_port = ProtoTuple::DestinationPort(443);
+
+    let orig_ip_tuple = Tuple::Ip(vec![orig_src_addr, orig_dst_addr]);
+    let orig_proto_tuple =
+        Tuple::Proto(vec![orig_proto_num, orig_src_port, orig_dst_port]);
+
+    let reply_src_addr = IPTuple::SourceAddress(IpAddr::V6(
+        "2404:6800:4007:839::200a".parse().unwrap(),
+    ));
+    let reply_dst_addr = IPTuple::DestinationAddress(IpAddr::V6(
+        "2409:40c4:2c:433d:8a2b:74e7:61f9:d824".parse().unwrap(),
+    ));
+
+    let reply_proto_num = ProtoTuple::Protocol(Protocol::Udp);
+    let reply_src_port = ProtoTuple::SourcePort(443);
+    let reply_dst_port = ProtoTuple::DestinationPort(36289);
+
+    let reply_ip_tuple = Tuple::Ip(vec![reply_src_addr, reply_dst_addr]);
+    let reply_proto_tuple =
+        Tuple::Proto(vec![reply_proto_num, reply_src_port, reply_dst_port]);
+
+    let status = Status::DstNatDone
+        | Status::SrcNatDone
+        | Status::Confirmed
+        | Status::Assured
+        | Status::SeenReply;
+
+    let timeout = 115;
+    let mark = 0;
+
+    let attributes = vec![
+        ConntrackAttribute::CtaTupleOrig(vec![orig_ip_tuple, orig_proto_tuple]),
+        ConntrackAttribute::CtaTupleReply(vec![
+            reply_ip_tuple,
+            reply_proto_tuple,
+        ]),
+        ConntrackAttribute::CtaStatus(status),
+        ConntrackAttribute::CtaTimeout(timeout),
+        ConntrackAttribute::CtaMark(mark),
+    ];
+
+    let expected: NetfilterMessage = NetfilterMessage::new(
+        NetfilterHeader::new(ProtoFamily::IPv6, 0, 0),
+        ConntrackMessage::Delete(attributes),
+    );
+
+    let mut buffer = vec![0; expected.buffer_len()];
+    expected.emit(&mut buffer);
+
+    // Check if the serialization was correct
+    assert_eq!(buffer, raw);
+
+    let message_type = ((u8::from(Subsystem::Conntrack) as u16) << 8)
+        | (u8::from(ConntrackMessageType::Delete) as u16);
     // Check if the deserialization was correct
     assert_eq!(
         NetfilterMessage::parse_with_param(


### PR DESCRIPTION
DEPENDS ON: https://github.com/rust-netlink/netlink-packet-netfilter/pull/12
 
Adds support for conntrack entry deletion (`IPCTNL_MSG_CT_DELETE`).

Implemented the `ConntrackMessage::Delete` variant and the following `ConntrackNla` attributes required to specify a entry:

*   `CtaTupleReply`
*   `CtaStatus`
*   `CtaTimeout`
*   `CtaMark`

Serialization and deserialization are verified against `conntrack -D` packet captures for TCP/IPv4 and UDP/IPv6.

Added ProtoFamily, an enum that represents a protocol family in the Netfilter header.

`bitflags` bumped to v2.10.0