### PR TITLE
feat: conntrack 'new' message type

### DIFF
--- a/src/conntrack/message.rs
+++ b/src/conntrack/message.rs
@@ -10,6 +10,7 @@ use netlink_packet_core::{
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub enum ConntrackMessage {
+    New(Vec<ConntrackAttribute>),
     Get(Vec<ConntrackAttribute>),
     Delete(Vec<ConntrackAttribute>),
     Other {
@@ -18,12 +19,14 @@ pub enum ConntrackMessage {
     },
 }
 
+const IPCTNL_MSG_CT_NEW: u8 = 0;
 const IPCTNL_MSG_CT_GET: u8 = 1;
 const IPCTNL_MSG_CT_DELETE: u8 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ConntrackMessageType {
+    New,
     Get,
     Delete,
     Other(u8),
@@ -32,6 +35,7 @@ pub enum ConntrackMessageType {
 impl From<u8> for ConntrackMessageType {
     fn from(value: u8) -> Self {
         match value {
+            IPCTNL_MSG_CT_NEW => Self::New,
             IPCTNL_MSG_CT_GET => Self::Get,
             IPCTNL_MSG_CT_DELETE => Self::Delete,
             v => Self::Other(v),
@@ -42,6 +46,7 @@ impl From<u8> for ConntrackMessageType {
 impl From<ConntrackMessageType> for u8 {
     fn from(value: ConntrackMessageType) -> Self {
         match value {
+            ConntrackMessageType::New => IPCTNL_MSG_CT_NEW,
             ConntrackMessageType::Get => IPCTNL_MSG_CT_GET,
             ConntrackMessageType::Delete => IPCTNL_MSG_CT_DELETE,
             ConntrackMessageType::Other(v) => v,
@@ -52,6 +57,7 @@ impl From<ConntrackMessageType> for u8 {
 impl ConntrackMessage {
     pub fn message_type(&self) -> ConntrackMessageType {
         match self {
+            ConntrackMessage::New(_) => ConntrackMessageType::New,
             ConntrackMessage::Get(_) => ConntrackMessageType::Get,
             ConntrackMessage::Delete(_) => ConntrackMessageType::Delete,
             ConntrackMessage::Other { message_type, .. } => {
@@ -64,6 +70,9 @@ impl ConntrackMessage {
 impl Emitable for ConntrackMessage {
     fn buffer_len(&self) -> usize {
         match self {
+            ConntrackMessage::New(attributes) => {
+                attributes.as_slice().buffer_len()
+            }
             ConntrackMessage::Get(attributes) => {
                 attributes.as_slice().buffer_len()
             }
@@ -78,6 +87,9 @@ impl Emitable for ConntrackMessage {
 
     fn emit(&self, buffer: &mut [u8]) {
         match self {
+            ConntrackMessage::New(attributes) => {
+                attributes.as_slice().emit(buffer)
+            }
             ConntrackMessage::Get(attributes) => {
                 attributes.as_slice().emit(buffer)
             }
@@ -99,6 +111,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized>
         message_type: u8,
     ) -> Result<Self, DecodeError> {
         Ok(match ConntrackMessageType::from(message_type) {
+            ConntrackMessageType::New => {
+                let attributes = buf.parse_all_nlas(|nla_buf| {
+                    ConntrackAttribute::parse(&nla_buf)
+                })?;
+                ConntrackMessage::New(attributes)
+            }
             ConntrackMessageType::Get => {
                 let attributes = buf.parse_all_nlas(|nla_buf| {
                     ConntrackAttribute::parse(&nla_buf)


### PR DESCRIPTION
DEPENDS ON: https://github.com/rust-netlink/netlink-packet-netfilter/pull/14

Implemented the `New`/`IPCTNL_MSG_CT_NEW` conntrack message type.

Added a test for adding new TCP/IPv4 conntrack entries.